### PR TITLE
AboutUsの修正

### DIFF
--- a/pages/-CAbout.vue
+++ b/pages/-CAbout.vue
@@ -1,8 +1,10 @@
 <template>
-  <section class="pb-20">
+  <section class="lg:py-20 pt-14 pb-20">
     <div class="container mx-auto text-center px-8 sm:px-0">
       <UiTitle :title="'About Us'" />
-      <p class="mx-auto text-black mb-10 text-left w-full lg:w-3/5">
+      <p
+        class="mx-auto text-black mb-10 leading-loose text-left w-full lg:w-3/5"
+      >
         (仮)chatboxについてこの文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。
         この文章はダミーです。文字の大きさ、量、字間、行間等を確認するために入れています。この文章はダミーです。
       </p>


### PR DESCRIPTION
close #36 

## 修正箇所
AboutUsセクションのコーディング修正を行いました。


## PC

- [x] 1_about us見出しの上のpaddingをもう少し広めに修正

コーディング
![スクリーンショット 2020-07-10 15 41 57](https://user-images.githubusercontent.com/29808916/87124661-26e2d580-c2c4-11ea-8254-6b77d3d010a9.png)

カンプ
<img width="316" alt="スクリーンショット 2020-07-10 15 41 53" src="https://user-images.githubusercontent.com/29808916/87124666-29452f80-c2c4-11ea-844f-be81653f221f.png">

- [x] 2_テキストの行間を調整お願いします！

コーディング
![スクリーンショット 2020-07-10 15 41 59](https://user-images.githubusercontent.com/29808916/87124744-4679fe00-c2c4-11ea-89b0-072be80035d1.png)

カンプ
<img width="514" alt="スクリーンショット 2020-07-10 15 41 48" src="https://user-images.githubusercontent.com/29808916/87124722-3f52f000-c2c4-11ea-920b-c1c6a4eede3c.png">
