### PR TITLE
フッターのデザイン修正

### DIFF
--- a/components/layout/LFooter.vue
+++ b/components/layout/LFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="w-full pb-8">
+  <footer class="w-full pb-8 bg-ivory">
     <div class="flex mt-32 pb-6 justify-center items-center">
       <img class="mx-2" src="@/assets/image/footer/icon_mail.svg" />
       <p class="text-primary">
@@ -13,7 +13,7 @@
           Webにまつわるお悩み、<br />
           ご相談はお気軽にchatboxまで。
         </p>
-        <div class="lg:flex justify-center items-center">
+        <div class="lg:flex justify-center items-center px-5">
           <a
             class="L-footer__btn inline-block relative cursor-pointer text-base bg-white p-6 rounded text-primary text-center w-64 lg:w-1/2 lg:text-lg lg:p-8 transition ease-out duration-700 hover:opacity-75"
             href=""
@@ -37,9 +37,7 @@
       </div>
     </div>
     <div class="h-56 w-full bg-ivory">
-      <div
-        class="container px-5 lg:px-0 mx-auto text-primary text-xs lg:text-15px"
-      >
+      <div class="container px-5 mx-auto text-primary text-xs lg:text-15px">
         <nav class="pt-8 pb-5 border-b">
           <ul class="flex flex-wrap text-center">
             <li class="mb-4 lg:mb-0 w-4/12 lg:w-auto lg:border-r">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,15 +1,15 @@
 <template>
   <div>
-    <CHero class="p-index" />
-    <CIntro class="p-index__item" />
-    <CCreation v-if="creation" class="p-index__item" :creation="creation" />
-    <CTalking v-if="talking" class="p-index__item" :talking="talking" />
-    <CEnjoy v-if="enjoy" class="p-index__item" :enjoy="enjoy" />
-    <CMember v-if="member" class="p-index__item" :member="member" />
-    <CRecruit v-if="recruit" class="p-index__item" :recruit="recruit" />
-    <CNews class="p-index__item" />
-    <CAbout v-if="about" class="p-index__item" :about="about" />
-    <CContact v-if="contact" class="p-index__item" :contact="contact" />
+    <CHero />
+    <CIntro :intro="intro" />
+    <CCreation v-if="creation" :creation="creation" />
+    <CTalking v-if="talking" :talking="talking" />
+    <CEnjoy v-if="enjoy" :enjoy="enjoy" />
+    <CMember v-if="member" :member="member" />
+    <CRecruit v-if="recruit" :recruit="recruit" />
+    <CNews />
+    <CAbout v-if="about" :about="about" />
+    <CContact v-if="contact" :contact="contact" />
     <UiBanner v-if="newsData" :news="newsData" />
   </div>
 </template>


### PR DESCRIPTION
close #18 

以下の修正を行いました。ご確認よろしくお願いします。

## PC

- [x] コンテナからはみ出してるっぽい？ので現行サイトの挙動に合わせてコーディングお願いします！

コーディング
![スクリーンショット 2020-07-15 15 44 23](https://user-images.githubusercontent.com/29808916/87512951-dd72fb80-c6b2-11ea-95fe-3fba9eca12cf.png)

カンプ
<img width="840" alt="スクリーンショット 2020-07-15 15 44 26" src="https://user-images.githubusercontent.com/29808916/87512965-e532a000-c6b2-11ea-9dcd-13e0898bd09b.png">


以下の修正お願いします！

## sp

- [x] お知らせのバーがsp時にちょっと被ってるので、フッタのしたかぶらない程度に調整お願いします！

<img width="462" alt="スクリーンショット 2020-07-20 13 49 16" src="https://user-images.githubusercontent.com/29808916/87900604-d3c10d80-ca8f-11ea-9640-fe76a3afbb73.png">


以下の修正対応お願いします！

## pc&sp

- [x] お知らせバーの高さ分下に領域を広げてもらったのですが、背景色が白になっているので、こちらフッタのピンク？カラーにしてあげてください！

コーディング
お知らせバーがある状態
![スクリーンショット 2020-07-21 10 49 21](https://user-images.githubusercontent.com/29808916/88003545-13dfc900-cb40-11ea-86bc-b51942874016.png)

ない状態(TOP以外のページ)
https://chatbox2020.netlify.app/contact/
![スクリーンショット 2020-07-21 10 51 36](https://user-images.githubusercontent.com/29808916/88003576-29ed8980-cb40-11ea-9bc0-06e0a903f65a.png)



