### PR TITLE
お問い合わせページでfooterのcta?を隠す

### DIFF
--- a/components/layout/LFooter.vue
+++ b/components/layout/LFooter.vue
@@ -6,7 +6,7 @@
         お問い合わせはこちら
       </p>
     </div>
-    <div class="bg-primary h-500px text-center text-white">
+    <div v-if="!isContact" class="bg-primary h-500px text-center text-white">
       <div class="container px-5 lg:px-0 mx-auto">
         <div class="L-footer__triangle w-10 mx-auto"></div>
         <p class="pt-24 pb-16 lg:text-3xl tracking-widest">
@@ -95,7 +95,13 @@
 </template>
 
 <script>
-export default {}
+export default {
+  computed: {
+    isContact() {
+      return this.$route.path === '/contact'
+    },
+  },
+}
 </script>
 
 <style lang="scss" scoped>

--- a/components/layout/LFooter.vue
+++ b/components/layout/LFooter.vue
@@ -1,6 +1,6 @@
 <template>
-  <footer class="w-full pb-8 bg-ivory">
-    <div class="flex mt-32 pb-6 justify-center items-center">
+  <footer class="w-full pb-8 bg-ivory" :class="borderClass">
+    <div v-if="!isContact" class="flex mt-32 pb-6 justify-center items-center">
       <img class="mx-2" src="@/assets/image/footer/icon_mail.svg" />
       <p class="text-primary">
         お問い合わせはこちら
@@ -97,6 +97,11 @@ export default {
   computed: {
     isContact() {
       return this.$route.path === '/contact'
+    },
+    borderClass() {
+      return {
+        'border-t-2 border-primary': this.isContact,
+      }
     },
   },
 }

--- a/pages/-CAbout.vue
+++ b/pages/-CAbout.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="lg:py-20 pt-14 pb-20" v-if="about">
+  <section v-if="about" class="lg:py-20 pt-14 pb-20 bg-ivory">
     <div class="container mx-auto text-center px-5 sm:px-0">
       <UiTitle :title="about.title" us />
       <p

--- a/pages/-CCreation.vue
+++ b/pages/-CCreation.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="lg:mb-32" v-if="creation">
+  <section v-if="creation" class="lg:mb-32 bg-ivory">
     <div class="c-creation__head">
       <div class="container mx-auto px-5 sm:p-0">
         <UiTitle class="lg:mb-5" :title="creation.title" />
@@ -41,9 +41,9 @@
           />
           <ul class="text-primary text-xs ml-2 mt-3 lg:ml-3 lg:m-0 lg:text-sm">
             <li
-              class="mb-6"
               v-for="(item, index) in creation.keywords"
               :key="index"
+              class="mb-6"
             >
               {{ item.extra }}
             </li>

--- a/pages/-CEnjoy.vue
+++ b/pages/-CEnjoy.vue
@@ -1,5 +1,5 @@
 <template>
-  <section v-if="enjoy" class="lg:mb-32">
+  <section v-if="enjoy" class="lg:mb-32 bg-ivory">
     <div class="c-enjoy__head">
       <div class="container mx-auto px-5 sm:p-0">
         <UiTitle :title="enjoy.title" />

--- a/pages/-CMember.vue
+++ b/pages/-CMember.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="pb-10" v-if="member">
+  <section v-if="member" class="pb-10">
     <div class="container mx-auto text-black px-5 sm:p-0">
       <UiTitle class="lg:mb-6" :title="member.title" />
       <div class="c-member__bg bg-no-repeat bg-contain pt-24 lg:pt-64">

--- a/pages/-CNews.vue
+++ b/pages/-CNews.vue
@@ -1,9 +1,9 @@
 <template>
-  <section class="pt-5 lg:pt-10 pb-10 px-5">
+  <section class="pt-5 lg:pt-10 pb-8 lg:pb-20 px-5">
     <div class="container mx-auto">
       <div class="pr-5 pl-5 lg:p-0">
         <UiTitle :title="'News'" />
-        <ol class="lg:flex flex-col space-y-8 lg:space-y-10 mt-8 lg:mt-16">
+        <ol class="lg:flex flex-col space-y-8 lg:space-y-10 mt-8">
           <li v-for="(news, index) in newsList" :key="index" class="bg-white">
             <nuxt-link
               class="lg:flex flex-row items-center hover:opacity-75"
@@ -13,7 +13,7 @@
                 class="flex flex-row space-x-3 lg:space-x-10 items-center lg:justify-around"
               >
                 <p
-                  class="inline-block font-medium text-xs lg:text-xl lg:text-black"
+                  class="inline-block font-medium text-xs text-primary lg:text-black lg:text-xl lg:text-black"
                 >
                   {{ createdDate(news.createdAt) }}
                 </p>
@@ -52,7 +52,7 @@ export default {
   },
   methods: {
     createdDate(createdAt) {
-      return this.$dayjs(createdAt.toDate()).format('MM/DD')
+      return this.$dayjs(createdAt.toDate()).format('YYYY/MM/DD')
     },
   },
 }

--- a/pages/-CRecruit.vue
+++ b/pages/-CRecruit.vue
@@ -1,10 +1,11 @@
 <template>
-  <section class="pb-20 pt-10 mt-20 bg-ivory" v-if="recruit">
-    <div class="container mx-auto text-center mt-8 relative px-5 sm:px-0">
-      <div class="c-recruit__head absolute">
-        <UiTitle :title="recruit.title" />
+  <section v-if="recruit" class="pb-20 mt-20 bg-ivory">
+    <div class="container mx-auto text-left mt-8 relative px-5 sm:px-0">
+      <div class="c-recruit__head">
+        <UiTitle :title="recruit.title" class="lg:mb-5" />
       </div>
     </div>
+
     <div class="container mx-auto text-center mt-8 relative px-5 sm:px-0">
       <img
         class="mb-12"
@@ -29,6 +30,9 @@ export default {
       type: Object,
       required: true,
     },
+  },
+  mounted() {
+    console.log(this.recruit)
   },
 }
 </script>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <CHero />
-    <CIntro :intro="intro" />
+    <CIntro v-if="intro" :intro="intro" />
     <CCreation v-if="creation" :creation="creation" />
     <CTalking v-if="talking" :talking="talking" />
     <CEnjoy v-if="enjoy" :enjoy="enjoy" />
@@ -76,13 +76,3 @@ export default {
   },
 }
 </script>
-
-<style lang="scss" scoped>
-.p-index {
-  &__item {
-    &:nth-child(2n + 3) {
-      background-color: #faf7f7;
-    }
-  }
-}
-</style>


### PR DESCRIPTION
close #58 
 
現行サイトに合わせてお問い合わせページでは、footerのctaが削除されるように変更しました。
ご確認よろしくお願いします。

以下の修正対応お願いします！

## pc

- [x] フッタのお問い合わせ部分をこのページに関しては現行ページ通り削除お願いします。

コーディング
![スクリーンショット 2020-07-21 10 31 14](https://user-images.githubusercontent.com/29808916/88002374-5a7ff400-cb3d-11ea-9240-b66eac10422f.png)

現行サイト
![スクリーンショット 2020-07-21 10 31 17](https://user-images.githubusercontent.com/29808916/88002379-5ce24e00-cb3d-11ea-82a2-082d4268cc85.png)

